### PR TITLE
Update MovieServiceImpl

### DIFF
--- a/src/main/java/com/barclays/movies/service/MovieServiceImpl.java
+++ b/src/main/java/com/barclays/movies/service/MovieServiceImpl.java
@@ -53,7 +53,12 @@ public class MovieServiceImpl implements MovieService {
         if(optMovie.isPresent()) {
             movie = optMovie.get();
         }else {
-            movie = movieRepository.getReferenceById(1L);
+            movie = new Movie();
+            Movie defaultMovie = movieRepository.getReferenceById(1L);
+            movie.setTitle(defaultMovie.getTitle());
+            movie.setIsbn(defaultMovie.getIsbn());
+            movie.setMovieType(defaultMovie.getMovieType());
+            //movie = movieRepository.getReferenceById(1L);
         }
         return movie;
     }


### PR DESCRIPTION
Bug where trying to add a new movie instead replaces movie with id = 1.  

When navigating to /movie/add, the findById() service is called with null ID. This poplates the form with id reference = 1. When this form is sent via post method, an ID of 1 is passed.

Changed the default movie else block to include all fields except ID for the user form. When sent via post method, this will pass an empty ID field which will be auto incremented during the repo.saveAndFlush() method.